### PR TITLE
Update header.html to avoid problems with RSS

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,10 +13,10 @@
 
     <title>{{ .Title }} -- {{ .Site.Title }}</title>
 
-    {{ if .RSSLink }}
-    <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-    <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
-    {{ end }}
+    <!-- RSS -->
+    {{ range .AlternativeOutputFormats -}}
+        {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+    {{ end -}}
 
     <!-- Bootstrap Core CSS -->
     <link href="{{ .Site.BaseURL }}/css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
I got this error: 
``` bash
WARN 2020/04/13 22:49:57 Page.RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like:
    {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}
```
So I created this fix which seems to work. Would be good to integrate that into the official theme.